### PR TITLE
fine tune user/vote relationship

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,6 +1,11 @@
 class VotesController < ApplicationController
+
+  def index
+    @users = User.all
+  end
+
 	def create
-		vote = Vote.new(selection: params[:user_id], comment: params[:comment])
+		vote = Vote.new(selection: params[:selection_id], comment: params[:comment])
 		vote.save
 		flash[:alert] = "You did it!"
 		redirect_to root_url

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,0 @@
-class WelcomeController < ApplicationController
-	def index
-	end
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,11 @@
 class User < ActiveRecord::Base
-	has_many :votes
+	has_many :votes, class_name: "Vote", foreign_key: "voter_id"
+	has_many :selections, class_name: "Vote", foreign_key: "selection_id"
+	
 	validates_presence_of :first_name, :last_name
-	validate :name_is_unique
-	def name_is_unique
-		true
-		#jacob will make this better
-	end
+
 	def full_name
 		self.first_name + " " + self.last_name
 	end
+
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,3 +1,15 @@
 class Vote < ActiveRecord::Base
-	belongs_to :user
+	belongs_to :voter, class_name: "User"
+  belongs_to :selection, class_name: "User"
+
+  validates_presence_of :selection #, :voter
+
+  # make scopes for:
+    # scope :for_user, -> (user) { where(voter_id: user.id) }
+    # scope :by_user, -> (user) { where(selection_id: user.id) }
+
+  # make methods for:
+    # winner_of(month, year)
+    # last_winner
+    # current_leader
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 <% flash.each do |name, msg| -%>
  <%= content_tag :div, msg, class: name %>
 <% end -%>
+
 <%= yield %>
 
 </body>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -3,9 +3,10 @@
 		<img class="logo" src="/assets/logo.svg" alt="Bonfire Red Logo">
 		<h1>How we make things is just as important as what we make</h1>
 		<p>Bonfire Red was built around the idea that great work should be challenging, and the challenge should be fun. We strive to maintain an open culture where everyone is a contributor and feels comfortable sharing ideas and opinions. It’s really the people that make Bonfire Red the kind of company it is. This is one way we can highlight individual associates for adding fuel to our flame.</p>
+		
 		<%= form_tag("/votes", method: "post") do %>
-		  <%= label_tag(:user_id, "Vote:") %>
-		  <%= select_tag :user_id, options_from_collection_for_select(User.all, 'id', 'full_name') %>
+		  <%= label_tag(:selection_id, "Vote:") %>
+		  <%= select_tag :selection_id, options_from_collection_for_select(@users, 'id', 'full_name') %>
 		  <%= label_tag(:comment, "Comment:") %>
 		  <%= text_area_tag('comment') %>
 		  <%= submit_tag("Submit") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,12 @@ Rails.application.routes.draw do
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
-  root 'welcome#index'
+  root 'votes#index'
 
   # Example of regular route:
-    # get 'welcome/index'
-    get 'users/:id' => 'users#show', as: 'user'
-    get 'users' => 'users#index'
-    post 'votes' => 'votes#create'
+  get 'users/:id' => 'users#show', as: 'user'
+  get 'users' => 'users#index'
+  post 'votes' => 'votes#create'
 
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase

--- a/db/migrate/20150129135532_create_votes.rb
+++ b/db/migrate/20150129135532_create_votes.rb
@@ -1,8 +1,8 @@
 class CreateVotes < ActiveRecord::Migration
   def change
     create_table :votes do |t|
-      t.integer :user_id
-      t.integer :selection
+      t.references :voter, index: true
+      t.references :selection
       t.string :comment
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,11 +22,13 @@ ActiveRecord::Schema.define(version: 20150129135532) do
   end
 
   create_table "votes", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "selection"
+    t.integer  "voter_id"
+    t.integer  "selection_id"
     t.string   "comment"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
+
+  add_index "votes", ["voter_id"], name: "index_votes_on_voter_id"
 
 end


### PR DESCRIPTION
I fixed up the relationship between the `User` and `Vote` models.

Now we can do things like this:
(`user = User.last')
`user.votes`=> all votes that user has cast.
`user.selections` => all votes cast for that user.

We also have more control on the `Vote` side of the spectrum:

(`vote = Vote.last`)
`vote.voter` => the user who cast the vote.
`vote.selection` => the user being voted for. 

I still don't like using the word "selection", but we are stuck it with it or something like it. We can't change "selection" to "vote", because `user.votes` wouldn't know whether to references the user's cast votes, or votes cast for that user. Still better than it was though!
